### PR TITLE
mejora para no acceder a mongo por alumno

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,17 +7,11 @@ buildscript {
         mavenCentral()
         mavenLocal()
     }
-    /*
-    dependencies {
-        classpath 'com.sourcemuse.gradle.plugin:gradle-mongo-plugin:0.13.0'
-    }*/
 }
 
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'application'
-//apply plugin: 'mongo'
-
 
 repositories {
     mavenCentral()
@@ -46,27 +40,7 @@ dependencies {
     //compile group: 'joda-time', name: 'joda-time', version: '2.9.4'
     compile group: 'com.typesafe', name: 'config', version: '1.3.1'
 
-
-/*
-    testCompile 'junit:junit:4.10'
-
-    buildTypes{
-        debug
-        release
-    }*/
 }
-
-/*
-run {
-    runWithMongoDb = true
-}
-
-mongo {
-    port 27017
-    logging 'console'
-    mongoVersion '3.2.0'
-    //storageLocation '/data/db'
-}*/
 
 //create a single Jar with all dependencies
 task deploy(type: Jar) {

--- a/src/main/java/unq/api/controller/SurveyController.java
+++ b/src/main/java/unq/api/controller/SurveyController.java
@@ -85,7 +85,7 @@ public class SurveyController {
             return HttpServletResponse.SC_OK;
         });
 
-        get("/surveyscompletition", (request, response) -> {
+        get("/surveysCompletition", (request, response) -> {
             response.type("application/json");
             return surveyService.getPercentageCompletedSurveys();
         });

--- a/src/main/java/unq/api/service/impl/SurveyServiceImpl.java
+++ b/src/main/java/unq/api/service/impl/SurveyServiceImpl.java
@@ -44,7 +44,7 @@ public class SurveyServiceImpl implements SurveyService {
     @Override
     public Survey getSurveyByStudent(String studentId) {
         LOGGER.info("Getting survey by student "+studentId);
-        return this.mongoDAO.getSurveyByStudent(studentId);
+        return mongoDAO.getSurveyByStudent(studentId);
     }
 
     @Override
@@ -69,8 +69,8 @@ public class SurveyServiceImpl implements SurveyService {
 
         LOGGER.info("Getting class occupation");
         List<ClassOccupation> classOccupations = new ArrayList<>();
-        List<Survey> surveys = this.mongoDAO.getSurveys();
-        List<Subject> subjects = this.mongoDAO.getSubjects();
+        List<Survey> surveys = mongoDAO.getSurveys();
+        List<Subject> subjects = mongoDAO.getSubjects();
         List<SelectedSubject> totalSelectedSubjects = new ArrayList<>();
 
         for(Survey survey: surveys){
@@ -117,18 +117,19 @@ public class SurveyServiceImpl implements SurveyService {
     }
 
 
-    private boolean completedSurvey(String id){
-        Survey survey = this.mongoDAO.getSurveyByStudent(id);
-        return (survey != null);
+    private boolean completedSurvey(String id, List<Survey> surveys){
+        Stream<Survey> studentSurvey = surveys.stream().filter(survey -> survey.getLegajo().equals(id));
+        return (studentSurvey.count()>0);
     }
 
     @Override
     public double getPercentageCompletedSurveys(){
-        List <Student> students = this.mongoDAO.getStudents();
+        List <Student> students = mongoDAO.getStudents();
+        List<Survey> surveys = mongoDAO.getSurveys();
         int totalStudents = students.size();
         int counter = 0;
         for(Student student: students){
-            if (this.completedSurvey(student.getLegajo())) counter++;
+            if (this.completedSurvey(student.getLegajo(), surveys)) counter++;
         }
         return (counter*100)/totalStudents;
     }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 
-env=prod
+env=local
 
 prod {
     port = 9091


### PR DESCRIPTION
Mejora en el método completedSurvey para no ir a mongo por alumno (puede generar muchas queries con mucho trafico de usuarios). Traemos todas las encuestas y filtramos por alumno sobre la lista.
También de paso hice una limpieza en el build de gradle que habia mucho código comentado.